### PR TITLE
ログファイルを誤って Git に追加してしまわないよう .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+# Log files
+*_.txt


### PR DESCRIPTION
ログファイルのファイル名パターンを .gitignore に追加しました。